### PR TITLE
Fix Nova >=3.9.0 compatibility

### DIFF
--- a/src/DynamicSelect.php
+++ b/src/DynamicSelect.php
@@ -26,7 +26,7 @@ class DynamicSelect extends Field
         return array_merge([
             'options' => $this->getOptions($this->dependentValues),
             'dependsOn' => $this->getDependsOn(),
-            'dependValues' => $this->dependentValues,
+            'dependValues' => count($this->dependentValues) ? $this->dependentValues :  new \ArrayObject(),
         ], $this->meta);
     }
 }


### PR DESCRIPTION
An error occurrs on Nova >=3.9.0 when `dependentValues` array is empty.
The array is serialized as a javascript array, insteadof an object.
But the VuesJS part need an object value not an array.

This patch fix the issue.