### PR TITLE
single select values does not save due to a bug

### DIFF
--- a/src/DynamicSelect.php
+++ b/src/DynamicSelect.php
@@ -93,7 +93,7 @@ class DynamicSelect extends Field
                 $model->{$attribute} = $values;
             }
         } else {
-            $model->{$attribute} = $value;
+            $model->{$attribute} = $request->input($requestAttribute);
         }
     }
 


### PR DESCRIPTION
When updating resource with single (I mean not multiselect) dynamic selects, it throws "Unknown variable $value".